### PR TITLE
XBoxContoller getStick method no longer throws errors

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -139,11 +139,12 @@
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
 	<storageModule moduleId="refreshScope" versionNumber="2">
-		<configuration configurationName="Debug">
-			<resource resourceType="PROJECT" workspacePath="/FRC15"/>
-		</configuration>
 		<configuration configurationName="Simulate">
 			<resource resourceType="PROJECT" workspacePath="/FRC15"/>
 		</configuration>
+		<configuration configurationName="Debug">
+			<resource resourceType="PROJECT" workspacePath="/FRC15"/>
+		</configuration>
 	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
 </cproject>

--- a/.settings/language.settings.xml
+++ b/.settings/language.settings.xml
@@ -5,10 +5,11 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="false" env-hash="40745501756267716" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="false" env-hash="47759356404484577" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
+			<provider-reference id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" ref="shared-provider"/>
 		</extension>
 	</configuration>
 	<configuration id="cdt.managedbuild.config.gnu.cross.exe.debug.1104744751.2017904325" name="Simulate">

--- a/src/XBoxController.h
+++ b/src/XBoxController.h
@@ -7,7 +7,7 @@
 
 class XBoxController {
 private:
-	Joystick joystick;
+	Joystick joystick = XBoxController;
 
 	const int leftStickXId = 1;
 	const int leftStickYId = 2;
@@ -17,6 +17,7 @@ private:
 
 public:
 	XBoxController(Joystick joystick);
+	XBoxController(XBoxController const&);
 
 	Vector2 getStick(int xId, int yId);
 


### PR DESCRIPTION
It seemed the errors were being thrown due to Eclipse's code analysis tool. I declared the Xboxcontroller class as suggested from #1, and then I followed the instructions here: http://stackoverflow.com/questions/14835869/eclipse-signals-an-error-but-the-code-compiles. While the stupid "within this context" bug still exists, there are no longer errors on the XBoxController getStick method. 
